### PR TITLE
feat: Create Spring Security Authentication Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Build artifacts
+target/
+
+# Log files
+*.log
+mvnw
+mvnw.cmd
+
+# IDE files
+.idea/
+*.iml
+.classpath
+.project
+.settings/
+.vscode/
+
+# Misc
+.DS_Store

--- a/1_FILTER_CHAIN_ADAVI.md
+++ b/1_FILTER_CHAIN_ADAVI.md
@@ -1,0 +1,49 @@
+# Chapter 1: The Filter Chain Forest (Filter Chain Adavi 🌳)
+
+Mana journey lo first stop, **The Filter Chain Forest**. Idi chala pedda adavi. Ee adavi lo chala "dwaralu" (gates) untayi. Pratidi oka "Security Filter". Manam ee adavi daati vellali ante, ee filters anni pass avvali.
+
+Ee adavi ki main guard, **`FilterChainProxy`**. Veedu mana request ni chusi, ee adavi lo mana request ki saraina "trova" (path) எதுவோ చూపిస్తాడు.
+
+```mermaid
+graph TD
+    A[Nenu, the Request 🚶‍♂️] --> B(FilterChainProxy);
+    B --> C(SecurityFilter1);
+    C --> D(SecurityFilter2);
+    D --> E(SecurityFilter3);
+    E --> F(...and so on...);
+    F --> G[Destination 🎯];
+```
+
+## Asalu ee Filters em chestayi? (What do these filters do?)
+
+Prati filter ki oka specific pani untundi. Konni examples:
+
+-   `CsrfFilter`: Manam పంపిన request valid eh na, leka verey evaraina mana peru cheppi pampinara ani check chestundi.
+-   `UsernamePasswordAuthenticationFilter`: Manam username and password pampiste, daani gurinchi pattinchukuntundi. (Deeni gurinchi next chapter lo detail ga chuddam).
+-   `AuthorizationFilter`: Manaki oka particular page chuse "permission" unda leda ani check chestundi.
+
+Spring Security lo by default ga chala filters untayi. Manam `SecurityFilterChain` bean create chesinappudu, ee filters anni oka chain la form avtayi.
+
+Mana `SecurityConfig.java` lo ee code chudandi:
+
+```java
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers("/", "/home").permitAll()
+            .anyRequest().authenticated()
+        )
+        .formLogin(Customizer.withDefaults());
+
+    return http.build();
+}
+```
+
+Ikkada manam `http` object tho adukuntunnam ante, manam ee filter chain ni configure chestunnam anamata! For example, `.formLogin()` ani cheppagane, `UsernamePasswordAuthenticationFilter` active avtundi.
+
+Ee adavi lo manam safe ga unnam ante, ee filters valle!
+
+**Next Stop:** The first major gate, the `Authentication Filter`!
+
+[<-- Back to Main Story](./SPRING_SECURITY_KATHA.md) | [Next Chapter -->](./2_AUTHENTICATION_FILTER_GATE.md)

--- a/2_AUTHENTICATION_FILTER_GATE.md
+++ b/2_AUTHENTICATION_FILTER_GATE.md
@@ -1,0 +1,27 @@
+# Chapter 2: The Authentication Filter Gate (Authentication Filter Gate 🚪)
+
+Adavi daatam, ippudu manam oka pedda "kota dwaram" (fort gate) mundu unnam. Ee gate peru **`UsernamePasswordAuthenticationFilter`**. Ee gate daggara unna guard manalni aapi, mana "identity" adugutadu.
+
+Ee filter special ga `/login` path ki vache requests kosam wait chestu untundi. Manam form lo username and password pampinappudu, ee filter active avtundi.
+
+## Em Jarugutundi Ikkada? (What happens here?)
+
+1.  **Request Check:** Ee filter check chestundi, "Ee request `/login` ki vachinda? Mari POST method ah? Username and password unnaya?" ani.
+2.  **Token Creation:** Avunu ani anipiste, mana username and password ni teeskuni, oka "identity chit" (identity slip) create chestundi. Deenine `UsernamePasswordAuthenticationToken` antaru. Ee token lo mana credentials untayi, kani deeniki inka "stamp" (authentication) padaledu. So, it's an **unauthenticated token**.
+3.  **Forwarding:** Ee filter, ee "chit" ni teeskuni, valla "manager" ki pampistundi. Aa manager eh **`AuthenticationManager`**.
+
+```mermaid
+graph TD
+    A[Nenu, the Request 🚶‍♂️ with username/password] -->|/login path| B(UsernamePasswordAuthenticationFilter);
+    B -->|1. Check request| B;
+    B -->|2. Create Unauthenticated Token 🎟️| C(UsernamePasswordAuthenticationToken);
+    C -->|3. Please verify!| D(AuthenticationManager 🏰);
+```
+
+Mana `SecurityConfig.java` lo `formLogin(Customizer.withDefaults())` anagane, Spring ee `UsernamePasswordAuthenticationFilter` ni mana chain lo add chesestundi.
+
+So, ippudu mana "identity chit" `AuthenticationManager` daggara undi. Akkada em jarugutundo next chapter lo chuddam.
+
+**Next Stop:** The main fort, the `AuthenticationManager`!
+
+[<-- Previous Chapter](./1_FILTER_CHAIN_ADAVI.md) | [<-- Back to Main Story](./SPRING_SECURITY_KATHA.md) | [Next Chapter -->](./3_AUTHENTICATION_MANAGER_DURGAM.md)

--- a/3_AUTHENTICATION_MANAGER_DURGAM.md
+++ b/3_AUTHENTICATION_MANAGER_DURGAM.md
@@ -1,0 +1,50 @@
+# Chapter 3: The Authentication Manager Fort (Authentication Manager Durgam 🏰)
+
+Ippudu manam `AuthenticationManager` ane pedda "durgam" (fort) loki vacham. Idi oka Head Office anamata. Veedu pedda manager, so veedu prathi panini cheyadu. Veedu काम (work) ni vere vallaki delegate chestadu.
+
+Ee `AuthenticationManager` ki default implementation peru **`ProviderManager`**.
+
+### Interface vs. Class: A Clear Look
+
+Let's get this clear mawa.
+
+*   `AuthenticationManager`
+    *   **Idi oka Interface.** Idi "authentication ela cheyyali?" ane contract (niyamam) ni define chestundi. Deentlo `authenticate()` ane method untundi.
+
+*   `ProviderManager`
+    *   **Idi oka Class.** Idi `AuthenticationManager` interface ki Spring Security lo **default implementation**. Manam special ga em cheyyakapothe, Spring ee class ni use cheskuntundi. Ee `ProviderManager` eh, chala `AuthenticationProvider`s ni manage chestundi.
+
+Mana project lo, manam ekkada `ProviderManager` ni direct ga create cheyyaledu. Spring Boot auto-configuration eh daanini manakosam set chesestundi. Super kada!
+
+## ProviderManager Pani Enti? (What does the ProviderManager do?)
+
+1.  **Receive Token:** `UsernamePasswordAuthenticationFilter` pampina unauthenticated token 🎟️ ni `ProviderManager` receive cheskuntadu.
+2.  **Delegate to Providers:** `ProviderManager` ki chala mandi "sainikulu" (soldiers) untaru. Ee sainikulune **`AuthenticationProvider`s** antaru. `ProviderManager` ee token ni teeskuni, tana daggara unna prathi provider ki pampi, "Ee token ni evaraina verify cheyagalara?" ani adugutadu.
+3.  **Find the Right Provider:** Chala providers untaru (okati LDAP kosam, okati JWT kosam, etc.). Mana case lo, username/password authentication kosam unna provider peru **`DaoAuthenticationProvider`**. Ee provider "Nenu handle cheyagalanu!" ani munduku vastadu.
+4.  **Get Final Report:** `DaoAuthenticationProvider` pani poorthi chesi, result ni `ProviderManager` ki istundi. Aa result "Authenticated" ✅ or "Failed" ❌ avvochu.
+5.  **Return Authenticated Token:** Authentication successful aite, `ProviderManager` oka **fully authenticated token** create chesi, daani `UsernamePasswordAuthenticationFilter` ki tirigi pampistundi. Ee token lo mana roles/authorities anni untayi.
+
+```mermaid
+graph TD
+    subgraph AuthenticationManager Durgam
+        A(ProviderManager)
+        B(DaoAuthenticationProvider)
+        C(OtherProvider1)
+        D(OtherProvider2)
+    end
+
+    E[Unauthenticated Token 🎟️] --> A;
+    A -->|Ee token evaridi?| B;
+    A -->|Ee token evaridi?| C;
+    A -->|Ee token evaridi?| D;
+    B -->|Nendi! Nenu verify chesta!| A;
+    A -->|OK, chesi cheppu| B;
+    B -->|Verified! ✅| A;
+    A --> F[Fully Authenticated Token ✨];
+```
+
+So, `AuthenticationManager` oka manager laaga act chestundi, kani asalu verification pani chesedi `DaoAuthenticationProvider`. Daani gurinchi next chapter lo telusukundam.
+
+**Next Stop:** The magical world of `DaoAuthenticationProvider`!
+
+[<-- Previous Chapter](./2_AUTHENTICATION_FILTER_GATE.md) | [<-- Back to Main Story](./SPRING_SECURITY_KATHA.md) | [Next Chapter -->](./4_PROVIDER_AND_DAO_MAAYALOKAM.md)

--- a/4_PROVIDER_AND_DAO_MAAYALOKAM.md
+++ b/4_PROVIDER_AND_DAO_MAAYALOKAM.md
@@ -1,0 +1,45 @@
+# Chapter 4: The World of Providers & DAO Magic (Provider and DAO Maayalokam 🪄)
+
+Welcome to the magician's chamber! Ikkada asalu magic jarugutundi. Mana `ProviderManager` ki right hand, ee **`DaoAuthenticationProvider`**. Veede asalu detective work antha chesedi.
+
+## `DaoAuthenticationProvider` ela pani chestundi?
+
+Ee provider ki rendu "astralu" (weapons) kavali:
+
+1.  **`UserDetailsService`**: User gurinchi details teeskuni vache "doota" (messenger).
+2.  **`PasswordEncoder`**: Manam pampina password ni, database lo unna password tho compare chese "yantram" (machine).
+
+### The Process:
+
+1.  **Get Username:** `DaoAuthenticationProvider` token nunchi username (`user`) teeskuntadu.
+2.  **Call `UserDetailsService`**: Aa username ni `UserDetailsService` ki ichi, "Ee user details teeskurava" ani adugutadu.
+3.  **Receive `UserDetails`**: `UserDetailsService` database (or any other source) nunchi user details (username, ENCODED password, roles) teeskuni vachi, `DaoAuthenticationProvider` ki istundi. Ee object ni **`UserDetails`** antaru.
+4.  **Password Check**: Ippudu `DaoAuthenticationProvider` daggara rendu passwords unnayi:
+    *   Manam form lo type chesina password (from the token).
+    *   Database nunchi vachina encoded password (from `UserDetails`).
+    Ee rendu passwords ni `PasswordEncoder` ki isthadu. `PasswordEncoder` manam pampina plain password ni encode chesi, database lo unna encoded password tho match avtunda leda ani check chesi cheptundi.
+5.  **Success or Failure**: Password match aite, **Success!** ✅ Ledante, **Failure!** ❌.
+6.  **Report Back**: Ee result ni `DaoAuthenticationProvider` velli `ProviderManager` ki report chestundi.
+
+```mermaid
+graph TD
+    A[DaoAuthenticationProvider] -->|1. Username teeskuni| B(UserDetailsService);
+    B -->|2. "user" evaro kanukko| C(Database / User Source);
+    C -->|3. UserDetails object istunna| B;
+    B -->|4. Ikkada UserDetails unnayi| A;
+    A -->|5. Password check chey| D(PasswordEncoder);
+    subgraph Password Check
+        E[Form Password]
+        F[DB Encoded Password]
+    end
+    E --> D;
+    F --> D;
+    D -->|Match Ayinda?| A;
+    A -->|6. Authenticated! ✅| G(ProviderManager);
+```
+
+So, ee provider asalu lothullo ki velli verification chestundi. Kani deeniki user details andinchedi evaru? Adi `UserDetailsService`. Next chapter lo daani gurinchi chuddam.
+
+**Next Stop:** The secret agent, `UserDetailsService`!
+
+[<-- Previous Chapter](./3_AUTHENTICATION_MANAGER_DURGAM.md) | [<-- Back to Main Story](./SPRING_SECURITY_KATHA.md) | [Next Chapter -->](./5_USERDETAILS_RAHASYAM.md)

--- a/5_USERDETAILS_RAHASYAM.md
+++ b/5_USERDETAILS_RAHASYAM.md
@@ -1,0 +1,96 @@
+# Chapter 5: The UserDetails Secret (UserDetails Rahasyam 🤫)
+
+`DaoAuthenticationProvider` ki user details kaavali. Kani aa details ekkada nunchi vastayi? Database nuncha? In-memory nuncha? LDAP nuncha? Ee provider ki ee vishayam anavasaram. Daaniki kavalsindalla okate: `UserDetailsService` ane oka "secret agent" nunchi `UserDetails` object teeskuni ravali.
+
+Let's look at these two important interfaces.
+
+## Interface: `UserDetails`
+
+Idi modati rahasyam. Idi oka particular user gurinchi information hold chestundi. Deenilo unna important methods:
+-   `getUsername()`
+-   `getPassword()` (Important: idi encoded password avvali!)
+-   `getAuthorities()` (Roles/Permissions)
+-   `isAccountNonExpired()`, `isAccountNonLocked()`, etc.
+
+## Interface: `UserDetailsService`
+
+Idi rendo rahasyam, and the most important one. Idi oka interface. Deenilo oke okka method untundi: `loadUserByUsername(String username)`. Ee method username teeskuni, venakki oka `UserDetails` object ni istundi.
+
+**Idi oka bridge anamata**. `DaoAuthenticationProvider` ki mariyu mana user data (database, etc.) ki madhya lo ee bridge untundi.
+
+Now, let's see the different implementations of this interface in our project.
+
+---
+
+### Implementation 1: `InMemoryUserDetailsManager` (The Default World 🏞️)
+
+Idi Spring Security tho vache oka concrete **class**. Idi `UserDetailsService` interface ni implement chestundi.
+
+**Use Case:** Simple applications, testing, or demos kosam, manam users ni database lo kakunda, direct ga code lo ne define cheyyali anukunnappudu idi vaadatham.
+
+Mana **`default`** profile lo, manam `DefaultSecurityConfig.java` lo ee class ni use chesi, `userDetailsService` ane bean ni create chesam.
+
+`src/main/java/com/example/springsecuritystory/config/DefaultSecurityConfig.java`
+```java
+@Configuration
+@EnableWebSecurity
+@Profile("default")
+public class DefaultSecurityConfig {
+
+    // ... other beans
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.builder()
+            .username("user")
+            .password(passwordEncoder().encode("password"))
+            .roles("USER")
+            .build();
+
+        UserDetails admin = User.builder()
+            .username("admin")
+            .password(passwordEncoder().encode("admin"))
+            .roles("ADMIN", "USER")
+            .build();
+
+        // Ikkada chudandi: manam InMemoryUserDetailsManager ni return chestunnam
+        return new InMemoryUserDetailsManager(user, admin);
+    }
+
+    // ...
+}
+```
+
+---
+
+### Implementation 2: `CustomUserDetailsService` (Our Custom World 🧑‍💻)
+
+Real-world applications lo, users database lo untaru. So, manam `UserDetailsService` interface ni mana sonta class tho implement cheyyali.
+
+Mana **`custom`** profile lo, manam `CustomUserDetailsService` ane class create chesam.
+
+`src/main/java/com/example/springsecuritystory/service/CustomUserDetailsService.java`
+```java
+@Service
+@Profile("custom")
+public class CustomUserDetailsService implements UserDetailsService {
+
+    // ... (simulating a user list)
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // Our logic to get user from a list (or a database)
+        return users.stream()
+                .filter(user -> user.getUsername().equals(username))
+                .findFirst()
+                .orElseThrow(() -> new UsernameNotFoundException("User not found..."));
+    }
+}
+```
+Ikkada manam `UserDetailsService` ni implement chesi, mana custom logic raastunnam. `@Profile("custom")` annotation tho, ee class `custom` profile active ga unnapudu matrame create avtundi.
+
+Spring automatic ga ee implementation ni `DaoAuthenticationProvider` ki supply chestundi. Anduke deenini "secret agent" annam!
+
+**Next Stop:** Let's put it all together and look at our custom world.
+
+[<-- Previous Chapter](./4_PROVIDER_AND_DAO_MAAYALOKAM.md) | [<-- Back to Main Story](./SPRING_SECURITY_KATHA.md) | [Next Chapter -->](./6_CUSTOM_LOKAM.md)

--- a/6_CUSTOM_LOKAM.md
+++ b/6_CUSTOM_LOKAM.md
@@ -1,0 +1,96 @@
+# Chapter 6: Our Custom World (Mee Sonta Prapancham 🧑‍💻)
+
+Eppudu manam katha antha chusam. Default ga Spring ela pani chestundo, and manam daanini ela customize cheyyagalamo chusam. Let's review the two worlds we built.
+
+## The Two Worlds: Default vs. Custom
+
+Mana project lo ippudu rendu prapanchalu unnayi, and manam Spring Profiles tho vaati madhya switch avvochu. Ee rendu prapanchalaki unna theda vaati Security Configuration lone undi.
+
+---
+
+### Default World Configuration (`@Profile("default")`)
+
+Idi `DefaultSecurityConfig.java` lo undi. Deeni key feature entante, `UserDetailsService` bean ni **ikkade, local ga** define chestundi, `InMemoryUserDetailsManager` ni use chesi.
+
+`src/main/java/com/example/springsecuritystory/config/DefaultSecurityConfig.java`
+```java
+@Configuration
+@EnableWebSecurity
+@Profile("default")
+public class DefaultSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/", "/home").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.builder()
+            .username("user")
+            .password(passwordEncoder().encode("password"))
+            .roles("USER")
+            .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+```
+
+---
+
+### Custom World Configuration (`@Profile("custom")`)
+
+Idi `CustomSecurityConfig.java` lo undi. Ikkada manam `UserDetailsService` bean ni define cheyyatledu. Manam create chesina `CustomUserDetailsService` (`@Service` and `@Profile("custom")` tho) ni Spring automatic ga pick cheskuntundani nammutunnam.
+
+`src/main/java/com/example/springsecuritystory/config/CustomSecurityConfig.java`
+```java
+@Configuration
+@EnableWebSecurity
+@Profile("custom")
+public class CustomSecurityConfig {
+
+    // Notice: No UserDetailsService bean here!
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/", "/home").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+```
+Ee approach tho, manam a profile ni activate chestamo, daaniki sambandinchina security rules matrame apply avtayi.
+
+## The Final Picture
+
+Mana `customuser` login avvali ante, journey ila untundi:
+
+`Filter` -> `Manager` -> `Provider` -> `CustomUserDetailsService` -> `PasswordEncoder` -> **SUCCESS!** 🎉
+
+Ippudu "Nenu, the Request" successfully authenticate ayyi, `SecurityContext` lo save avtundi. Finally, mana destination aina `/welcome` page ki reach avtundi.
+
+**The End.**
+
+Congratulations! You have completed the story of Spring Security Username/Password Authentication.
+
+[<-- Previous Chapter](./5_USERDETAILS_RAHASYAM.md) | [<-- Back to Main Story](./SPRING_SECURITY_KATHA.md)

--- a/SPRING_SECURITY_KATHA.md
+++ b/SPRING_SECURITY_KATHA.md
@@ -1,0 +1,67 @@
+# Spring Security Katha 🚶‍♂️🔒
+
+Namaste! Welcome to the story of Spring Security. Ee katha lo manam oka HTTP Request la udham. Mana peru **"Nenu, the Request"**. Manam browser nunchi bayalderi, server lo unna mana destination (oka Controller method) ki reach avvali.
+
+But ee journey antha easy kaadu. Madhya lo chala "checkposts" ⚔️ untayi. Ee checkposts ye Spring Security anamata. Vaallu manalni aapi, "Evaru nuvvu? Enduku vachav?" ani adugutaru. Manam saraina credentials chupiste gani munduku vellaniyyaru.
+
+Ee katha lo, manam ee checkposts anni ela daatukuntu veltamo chuddam. Ready ah? Let's begin the adventure!
+
+## The Journey Map (Mana Prayanam)
+
+Ikkada manam follow avaboye high-level path undi. Pratidi oka "chapter" anamata.
+
+```mermaid
+graph TD
+    A[Browser lo User 🧑‍💻] -->|1. Request for /welcome| B(Tomcat Server);
+    B --> C{Security Filter Chain 🌳};
+    C -->|Request Pass Avtundi| D(UsernamePasswordAuthenticationFilter 🚪);
+    D -->|Credentials unnay!| E(AuthenticationManager 🏰);
+    E -->|Nee pani chudu!| F(DaoAuthenticationProvider 🧙‍♂️);
+    F -->|User evaro cheppu?| G(CustomUserDetailsService 🧑‍💻);
+    G -->|User unnadu, password check chey| F;
+    F -->|Password OK!| E;
+    E -->|Authenticated! ✅| D;
+    D -->|Ponee!| H(Controller Endpoint 🎯);
+    H -->|Response istunna| A;
+
+    style A fill:#f9f,stroke:#333,stroke-width:2px
+    style H fill:#9f9,stroke:#333,stroke-width:2px
+```
+
+## Bonus Chapter: Switching Between Worlds (Default vs. Custom) 🎭
+
+Ee project lo manam rendu rakala security configurations create chesam:
+
+1.  **Default World**: Idi `DefaultSecurityConfig.java` lo undi. Deentlo `user` and `admin` ane ఇద్దరు users in-memory lo create chesam. Idi `@Profile("default")` tho mark cheyabadindi.
+2.  **Custom World**: Idi `CustomSecurityConfig.java` lo undi. Idi mana `CustomUserDetailsService` ni use cheskuntundi, adi `customuser` ni load chestundi. Idi `@Profile("custom")` tho mark cheyabadindi.
+
+By default, Spring Boot `default` profile ni activate chestundi. So, meeru application ni run cheste, `user/password` tho login avvochu.
+
+**Custom World ni ela activate cheyali?**
+
+`src/main/resources/` folder lo `application.properties` ane file create chesi, daantlo ee line add cheyandi:
+
+```properties
+spring.profiles.active=custom
+```
+
+Ila chesi application ni restart cheste, Spring Boot `default` profile ni ignore chesi, `custom` profile ni activate chestundi. Appudu meeru `customuser/custompass` tho login avvagalaru.
+
+Marala default ki vellali ante, aa line ni comment cheyandi (`#spring.profiles.active=custom`) or `spring.profiles.active=default` ani marchandi.
+
+Idhe Spring Profiles magic!
+
+---
+
+## The Chapters (Adhyayalu)
+
+Ee journey lo prathi "checkpost" gurinchi detail ga telusukodaniki, kindha unna links click cheyandi.
+
+1.  [**Chapter 1: The Filter Chain Forest (Filter Chain Adavi 🌳)**](./1_FILTER_CHAIN_ADAVI.md) - Asalu ee security antha ekkada start avtundi?
+2.  [**Chapter 2: The Authentication Filter Gate (Authentication Filter Gate 🚪)**](./2_AUTHENTICATION_FILTER_GATE.md) - Manalni first aape checkpost.
+3.  [**Chapter 3: The Authentication Manager Fort (Authentication Manager Durgam 🏰)**](./3_AUTHENTICATION_MANAGER_DURGAM.md) - The main boss who delegates the work.
+4.  [**Chapter 4: The World of Providers & DAO Magic (Provider and DAO Maayalokam 🪄)**](./4_PROVIDER_AND_DAO_MAAYALOKAM.md) - The real detective who does the verification.
+5.  [**Chapter 5: The UserDetails Secret (UserDetails Rahasyam 🤫)**](./5_USERDETAILS_RAHASYAM.md) - Mana gurinchi information ekkada store ayi untundi?
+6.  [**Chapter 6: Our Custom World (Custom Lokam 🧑‍💻)**](./6_CUSTOM_LOKAM.md) - Manam create chesina custom classes gurinchi.
+
+Mundu mundu ee chapters anni fill cheddam!

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.0</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>spring-security-story</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>spring-security-story</name>
+	<description>A project to explain Spring Security</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/example/springsecuritystory/SpringSecurityStoryApplication.java
+++ b/src/main/java/com/example/springsecuritystory/SpringSecurityStoryApplication.java
@@ -1,0 +1,13 @@
+package com.example.springsecuritystory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringSecurityStoryApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SpringSecurityStoryApplication.class, args);
+    }
+
+}

--- a/src/main/java/com/example/springsecuritystory/config/CustomSecurityConfig.java
+++ b/src/main/java/com/example/springsecuritystory/config/CustomSecurityConfig.java
@@ -1,0 +1,39 @@
+package com.example.springsecuritystory.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@Profile("custom")
+public class CustomSecurityConfig {
+
+    // This configuration is active only when the 'custom' profile is used.
+    // It relies on the CustomUserDetailsService @Service to be picked up automatically.
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/", "/home").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    // Note: The PasswordEncoder bean is defined here. If both profiles could be active at once,
+    // this could cause a conflict. But since we only activate one at a time, it's fine.
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/springsecuritystory/config/DefaultSecurityConfig.java
+++ b/src/main/java/com/example/springsecuritystory/config/DefaultSecurityConfig.java
@@ -1,0 +1,58 @@
+package com.example.springsecuritystory.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@Profile("default")
+public class DefaultSecurityConfig {
+
+    // This configuration is active by default, or when the 'default' profile is used.
+    // It creates a simple in-memory user store.
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/", "/home").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.builder()
+            .username("user")
+            .password(passwordEncoder().encode("password"))
+            .roles("USER")
+            .build();
+
+        UserDetails admin = User.builder()
+            .username("admin")
+            .password(passwordEncoder().encode("admin"))
+            .roles("ADMIN", "USER")
+            .build();
+
+        return new InMemoryUserDetailsManager(user, admin);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/springsecuritystory/controller/WebController.java
+++ b/src/main/java/com/example/springsecuritystory/controller/WebController.java
@@ -1,0 +1,25 @@
+package com.example.springsecuritystory.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class WebController {
+
+    @GetMapping({"/", "/home"})
+    public String home() {
+        return "home"; // Returns home.html
+    }
+
+    @GetMapping("/welcome")
+    public String welcome() {
+        return "welcome"; // Returns welcome.html (secured)
+    }
+
+    // Spring Security provides a default /login endpoint, but if you want a custom one,
+    // you can map it here. For now, we'll use the default.
+    // @GetMapping("/login")
+    // public String login() {
+    //     return "login"; // Returns login.html
+    // }
+}

--- a/src/main/java/com/example/springsecuritystory/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/springsecuritystory/service/CustomUserDetailsService.java
@@ -1,0 +1,42 @@
+package com.example.springsecuritystory.service;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Profile("custom")
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final PasswordEncoder passwordEncoder;
+
+    // We'll use a simple in-memory list to simulate a database.
+    private final List<UserDetails> users = new ArrayList<>();
+
+    public CustomUserDetailsService(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+        // Let's create a custom user for our service
+        users.add(
+            User.builder()
+                .username("customuser")
+                .password(this.passwordEncoder.encode("custompass"))
+                .roles("USER")
+                .build()
+        );
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return users.stream()
+                .filter(user -> user.getUsername().equals(username))
+                .findFirst()
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+    }
+}

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Spring Security Story</title>
+</head>
+<body>
+    <h1>Welcome to the Public Home Page!</h1>
+    <p>Everyone can see this page. 🌍</p>
+    <p>Click here to go to the secured page (you will be asked to log in): <a th:href="@{/welcome}">Go to Welcome Page</a></p>
+</body>
+</html>

--- a/src/main/resources/templates/welcome.html
+++ b/src/main/resources/templates/welcome.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome!</title>
+</head>
+<body>
+    <h1>Welcome to the Secured Page! 🛡️</h1>
+
+    <p>If you can see this, you have successfully logged in.</p>
+
+    <!-- Display username -->
+    <p>Hello, <span sec:authentication="name">User</span>!</p>
+
+    <!-- Display authorities/roles -->
+    <p>Your roles: <span sec:authentication="principal.authorities">Roles</span></p>
+
+    <p>Ready to go?
+        <form th:action="@{/logout}" method="post" style="display:inline;">
+            <button type="submit">Logout</button>
+        </form>
+    </p>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a complete Spring Boot project and accompanying documentation to explain the username and password authentication flow in Spring Security.

The project includes two distinct, runnable security configurations managed by Spring Profiles:
- 'default': Demonstrates the default flow using an InMemoryUserDetailsManager.
- 'custom': Demonstrates a custom flow using a dedicated UserDetailsService class.

The documentation is provided as a series of linked markdown files, written in a story-based format using Telugu in English script, with Mermaid diagrams and emojis as requested by the user. The guide explains the roles of the Filter Chain, AuthenticationManager, DaoAuthenticationProvider, and UserDetailsService.

This version incorporates user feedback to more clearly distinguish between interfaces and their default/custom implementations, and to explicitly show the profile-based configuration in the documentation.